### PR TITLE
update eciYali based on 4.1.1

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -1,10 +1,10 @@
 [BASE]
 url = https://github.com/SysBioChalmers/ecModels
 pull_request_target = feat/update_all_ecModels
-install_dir = /home/jenkins/ecModels-dependencies/
+install_dir = /home/m/ecModels-dependencies/
 
 [MATLAB]
-version = R2018b
+version = 3
 
 [COBRA]
 url = https://github.com/opencobra/cobratoolbox
@@ -23,7 +23,7 @@ install_dir = libSBML/
 
 [Gurobi]
 url = https://www.gurobi.com/downloads/gurobi-software/
-version = v8.1.1
+version = v9.1.1
 install_dir = gurobi/
 
 [GECKO]
@@ -35,7 +35,7 @@ branch = devel
 [ecYeastGEM]
 type = 'gem'
 url = https://github.com/SysBioChalmers/yeast-GEM
-download_url =
+download_url = 
 model_filename = /ModelFiles/mat/yeastGEM.mat
 mat_model = .model
 install_dir = yeast-GEM
@@ -45,17 +45,17 @@ database_tag = sce
 [eciYali]
 type = 'gem'
 url = https://github.com/SysBioChalmers/Yarrowia_lipolytica_W29-GEM
-download_url =
+download_url = 
 model_filename = /ModelFiles/mat/iYali.mat
 mat_model = .model
 install_dir = Yali-GEM
-version = v0
+version = 4.1.1
 database_tag = yli
 
 [eciSM966]
 type = 'gem'
 url = https://github.com/SysBioChalmers/Kluyveromyces_marxianus-GEM
-download_url =
+download_url = 
 mat_filename = /modelFiles/mat/Kluyveromyces_marxianus-GEM.mat
 mat_model = .model
 install_dir = iSM966
@@ -64,7 +64,7 @@ database_tag = kmx
 
 [eciML1515]
 type = 'gem'
-url =
+url = 
 download_url = http://bigg.ucsd.edu/static/models/iML1515.xml
 model_filename = /iML1515.xml
 mat_model = 
@@ -75,9 +75,10 @@ database_tag = eco
 [ecHumanGEM]
 type = 'gem'
 url = https://github.com/SysBioChalmers/Human-GEM
-download_url =
+download_url = 
 model_filename = /model/Human-GEM.mat
 mat_model = .ihuman
 install_dir = Human-GEM
 version = v0
 database_tag = hsa
+


### PR DESCRIPTION
MATLAB is selecting SOFTWARE OPENGL rendering.

                                                                              < M A T L A B (R) >
                                                                    Copyright 1984-2020 The MathWorks, Inc.
                                                                R2020b Update 3 (9.9.0.1538559) 64-bit (glnxa64)
                                                                               November 23, 2020

 
To get started, type doc.
For product information, visit www.mathworks.com.
 

***************************************************************
   GECKO: Adding enzyme constraints to a genome-scale model
***************************************************************

Getting genome-scale model ready...