### PR TITLE
fix/parse_matlab_version

### DIFF
--- a/tools.py
+++ b/tools.py
@@ -113,6 +113,8 @@ class GECKO_VM:
     def check_dependencies(self):
         # Check Matlab version
         cmd = sp.check_output(['/usr/local/bin/matlab', '-nodisplay -nosplash -nodesktop -r', '"disp(version); quit"'])
+        l.info(cmd)
+        l.info(cmd.decode('utf-8').split())
         m_version = ' '.join(cmd.decode('utf-8').split()[-1:]).replace('(','').replace(')','')
         if m_version != self.version('MATLAB'):
             l.warning('MATLAB changed from {} to {}'.format(self.version('MATLAB'), m_version))

--- a/tools.py
+++ b/tools.py
@@ -113,7 +113,7 @@ class GECKO_VM:
     def check_dependencies(self):
         # Check Matlab version
         cmd = sp.check_output(['/usr/local/bin/matlab', '-nodisplay -nosplash -nodesktop -batch', '"disp(version); quit"'])
-        m_version = re.findall(r'([R]\d{4}[a|b])',cmd.decode('utf-8'))[-1]
+        m_version = re.findall(r'([R]\d{4}\w+)',cmd.decode('utf-8'))[-1]
         if m_version != self.version('MATLAB'):
             l.warning('MATLAB changed from {} to {}'.format(self.version('MATLAB'), m_version))
             self.version('MATLAB', m_version)

--- a/tools.py
+++ b/tools.py
@@ -113,7 +113,7 @@ class GECKO_VM:
     def check_dependencies(self):
         # Check Matlab version
         cmd = sp.check_output(['/usr/local/bin/matlab', '-nodisplay -nosplash -nodesktop -batch', '"disp(version); quit"'])
-        m_version = re.findall(r'([R]\d{4}\w+)',cmd.decode('utf-8'))[-1]
+        m_version = re.findall(r'([R]\d{4}\w+)',cmd.decode('utf-8'))[0]
         if m_version != self.version('MATLAB'):
             l.warning('MATLAB changed from {} to {}'.format(self.version('MATLAB'), m_version))
             self.version('MATLAB', m_version)

--- a/tools.py
+++ b/tools.py
@@ -112,8 +112,12 @@ class GECKO_VM:
 
     def check_dependencies(self):
         # Check Matlab version
-        cmd = sp.check_output(['/usr/local/bin/matlab', '-nodisplay -nosplash -nodesktop -r', '"disp(version); quit"'])
-        m_version = ' '.join(cmd.decode('utf-8').split()[-3]).replace('(','').replace(')','')
+        cmd = sp.check_output(['/usr/local/bin/matlab', '-nodisplay -nosplash -nodesktop -batch', '"disp(version); quit"'])
+        l.info(cmd)
+        cmd = cmd.decode('utf-8').replace('MATLAB is selecting SOFTWARE OPENGL rendering.','')
+        l.info(cmd)
+        m_version = ' '.join(cmd.decode('utf-8').split()[0]).replace('\n','').replace('\n','')
+        l.info(m_version)
         if m_version != self.version('MATLAB'):
             l.warning('MATLAB changed from {} to {}'.format(self.version('MATLAB'), m_version))
             self.version('MATLAB', m_version)

--- a/tools.py
+++ b/tools.py
@@ -114,9 +114,9 @@ class GECKO_VM:
         # Check Matlab version
         cmd = sp.check_output(['/usr/local/bin/matlab', '-nodisplay -nosplash -nodesktop -batch', '"disp(version); quit"'])
         l.info(cmd)
-        cmd = cmd.decode('utf-8').replace('MATLAB is selecting SOFTWARE OPENGL rendering.','')
+        cmd = cmd.decode('utf-8').replace('MATLAB is selecting SOFTWARE OPENGL rendering.','').replace('\n','')
         l.info(cmd)
-        m_version = ' '.join(cmd.decode('utf-8').split()[0]).replace('\n','').replace('\n','')
+        m_version = ' '.join(cmd.split()[0])
         l.info(m_version)
         if m_version != self.version('MATLAB'):
             l.warning('MATLAB changed from {} to {}'.format(self.version('MATLAB'), m_version))

--- a/tools.py
+++ b/tools.py
@@ -113,11 +113,7 @@ class GECKO_VM:
     def check_dependencies(self):
         # Check Matlab version
         cmd = sp.check_output(['/usr/local/bin/matlab', '-nodisplay -nosplash -nodesktop -batch', '"disp(version); quit"'])
-        l.info(cmd)
-        cmd = cmd.decode('utf-8').replace('MATLAB is selecting SOFTWARE OPENGL rendering.','').replace('\n','')
-        l.info(cmd)
-        m_version = ' '.join(cmd.split()[0])
-        l.info(m_version)
+        m_version = cmd.decode('utf-8').replace('MATLAB is selecting SOFTWARE OPENGL rendering.','').replace('\n','')
         if m_version != self.version('MATLAB'):
             l.warning('MATLAB changed from {} to {}'.format(self.version('MATLAB'), m_version))
             self.version('MATLAB', m_version)

--- a/tools.py
+++ b/tools.py
@@ -6,7 +6,7 @@ import logging
 from os import getcwd, environ, mkdir
 import time
 import datetime
-
+import re
 
 # Constants
 CONFIGFILE = 'config.ini'
@@ -113,7 +113,7 @@ class GECKO_VM:
     def check_dependencies(self):
         # Check Matlab version
         cmd = sp.check_output(['/usr/local/bin/matlab', '-nodisplay -nosplash -nodesktop -batch', '"disp(version); quit"'])
-        m_version = cmd.decode('utf-8').replace('MATLAB is selecting SOFTWARE OPENGL rendering.','').replace('\n','')
+        m_version = re.findall(r'([R]\d{4}[a|b])',cmd.decode('utf-8'))[-1]
         if m_version != self.version('MATLAB'):
             l.warning('MATLAB changed from {} to {}'.format(self.version('MATLAB'), m_version))
             self.version('MATLAB', m_version)

--- a/tools.py
+++ b/tools.py
@@ -113,7 +113,7 @@ class GECKO_VM:
     def check_dependencies(self):
         # Check Matlab version
         cmd = sp.check_output(['/usr/local/bin/matlab', '-nodisplay -nosplash -nodesktop -r', '"disp(version); quit"'])
-        m_version = ' '.join(cmd.decode('utf-8').split()[1]).replace('(','').replace(')','')
+        m_version = ' '.join(cmd.decode('utf-8').split()[-3]).replace('(','').replace(')','')
         if m_version != self.version('MATLAB'):
             l.warning('MATLAB changed from {} to {}'.format(self.version('MATLAB'), m_version))
             self.version('MATLAB', m_version)

--- a/tools.py
+++ b/tools.py
@@ -113,9 +113,7 @@ class GECKO_VM:
     def check_dependencies(self):
         # Check Matlab version
         cmd = sp.check_output(['/usr/local/bin/matlab', '-nodisplay -nosplash -nodesktop -r', '"disp(version); quit"'])
-        l.info(cmd)
-        l.info(cmd.decode('utf-8').split())
-        m_version = ' '.join(cmd.decode('utf-8').split()[-1:]).replace('(','').replace(')','')
+        m_version = ' '.join(cmd.decode('utf-8').split()[1]).replace('(','').replace(')','')
         if m_version != self.version('MATLAB'):
             l.warning('MATLAB changed from {} to {}'.format(self.version('MATLAB'), m_version))
             self.version('MATLAB', m_version)


### PR DESCRIPTION
This PR solves a bug in the MATLAB version parsing step in the ecModels update pipeline. It has been detected that MATLAB version strings are composed of several parts: `version_id + release_id + update_#`. Depending on the version, not all strings may include the `update_#` part, which will return variable results if the version string, split into a list, is read in a backwards way.

The version parsing has been simplified by:
1. Running the `version` MATLAB command in batch mode (commit 5ec3c86), which reduces the log output of MATLAB commands executed on a command line interface.
2. Storing the whole version string, in order to avoid ambiguities or potential unintended results whenever a new MATLAB version is installed in the runner (commit 4cdbb66).

The new MATLAB version string can be seen [here](https://github.com/SysBioChalmers/ecModels/runs/1939105970?check_suite_focus=true#step:3:7).